### PR TITLE
Write workflow output to repo

### DIFF
--- a/.github/workflows/run_delays.yml
+++ b/.github/workflows/run_delays.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Cloner le dépôt
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Installer Python et dépendances
         uses: actions/setup-python@v4
@@ -21,8 +23,18 @@ jobs:
 
       - name: Exécuter le script
         run: |
-          python delays_gare_de_lyon.py
+          python delays_gare_de_lyon.py > gdl-retard.txt
 
       - name: Afficher la sortie
-        # Cette étape est optionnelle : elle affiche simplement les logs dans l'UI Actions
-        run: echo "Script exécuté avec succès"
+        # Cette étape affiche le contenu du fichier généré
+        run: cat gdl-retard.txt
+
+      - name: Commit file to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add gdl-retard.txt
+          git commit -m "Update gdl-retard.txt" || echo "No changes to commit"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}" HEAD:${{ github.ref }}

--- a/gdl-retard.txt
+++ b/gdl-retard.txt
@@ -1,0 +1,2 @@
+2025-06-18T09:20:00 | Train 6250 | from Perpignan | Swiss stops: - | +900s
+Total delayed trains: 1


### PR DESCRIPTION
## Summary
- save script output to `gdl-retard.txt`
- commit that file back to the repository using `${{ secrets.GITHUB_TOKEN }}`

## Testing
- `python3 delays_gare_de_lyon.py > gdl-retard.txt && tail -n 2 gdl-retard.txt`


------
https://chatgpt.com/codex/tasks/task_e_68527a3b56ec83298166723dec371ac0